### PR TITLE
Use companion object

### DIFF
--- a/src/main/scala/ScalaLirc.scala
+++ b/src/main/scala/ScalaLirc.scala
@@ -43,9 +43,8 @@ class ScalaLirc private(auxRemoteCodes: MutableMap[String, List[String]]) {
 
 }
 
-object ScalaLirc(sourceFile: String = "/etc/lirc/lircd.conf") {
-
-  def apply(sourceFile: String): Option[ScalaLirc] = {
+object ScalaLirc {
+  def apply(sourceFile: String = "/etc/lirc/lircd.conf"): Option[ScalaLirc] = {
     try {
       val file = Source.fromFile(sourceFile)
       val sourceLines = file.getLines.toList

--- a/src/test/scala/ScalaLircSpec.scala
+++ b/src/test/scala/ScalaLircSpec.scala
@@ -4,16 +4,30 @@ import org.scalatest.FunSpec
 
 class ScalaLircSpec extends FunSpec {
   describe("ScalaLirc") {
-    val lirc = new ScalaLirc("src/test/scala/lircd.conf.test.valid")
+    val lirc = ScalaLirc("src/test/scala/lircd.conf.test.valid")
+
+    it ("should exist for a valid conf file") {
+      assert(lirc.isDefined)
+    }
+
+    it ("should graciously fail when conf file not present") {
+      val lircNotExists = ScalaLirc("src/test/scala/does.not.exist")
+      assert(!lircNotExists.isDefined)
+    }
+
+    it ("should graciously fail when conf file is not valid") {
+      val lircBadFile = ScalaLirc("src/test/scala/ScalaLircSpec.scala")
+      assert(!lircBadFile.isDefined)
+    }
 
     it ("should detect remotes") {
       val remotes = Set("TestRemote1", "TestRemote2")
-      assert(lirc.devices.toSet === remotes)
+      assert(lirc.get.devices.toSet === remotes)
     }
 
     it("should detect all the codes for a remote") {
-      assert(lirc.codesForRemote("TestRemote1").size == 4)
-      assert(lirc.codesForRemote("TestRemote1").contains("KEY_BRIGHTNESSUP"))
+      assert(lirc.get.codesForRemote("TestRemote1").size == 4)
+      assert(lirc.get.codesForRemote("TestRemote1").contains("KEY_BRIGHTNESSUP"))
     }
   }
 }

--- a/src/test/scala/ScalaLircSpec.scala
+++ b/src/test/scala/ScalaLircSpec.scala
@@ -15,7 +15,7 @@ class ScalaLircSpec extends FunSpec {
       assert(!lircNotExists.isDefined)
     }
 
-    it ("should graciously fail when conf file is not valid") {
+    it ("should graciously fail when conf file is not a valid lirc conf file") {
       val lircBadFile = ScalaLirc("src/test/scala/ScalaLircSpec.scala")
       assert(!lircBadFile.isDefined)
     }


### PR DESCRIPTION
When failing to parse a `lircd.config` file, we should be able to reflect that through the object (i.e. returning a `None` or such) instead of just returning an empty object. This is way better when doing safe checking if the `ScalaLirc` object actually exists.
